### PR TITLE
Remove mysql flag for auth plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,6 @@ version: "3.1"
 services:
   db:
     image: mysql:8.1.0
-    command: --default-authentication-plugin=mysql_native_password
     ports:
       - 3306:3306
     environment:


### PR DESCRIPTION
Logs had ton of spam about `mysql_native_password` being deprecated. Drivers should support the mysql default choice `caching_sha2_password` just fine.