### PR TITLE
#15: Added Coveralls to GHA

### DIFF
--- a/.github/workflows/backend-deploy.yaml
+++ b/.github/workflows/backend-deploy.yaml
@@ -62,7 +62,10 @@ jobs:
           name: backend-code-coverage-report
           path: ./backend/coverage
 
-      # - name: Upload code coverage results to code coverage service
+      - name: Upload test coverage results to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          base-path: ./backend/coverage
 
   e2e-tests:
     uses: ./.github/workflows/e2e-tests.yaml

--- a/.github/workflows/backend-pr.yaml
+++ b/.github/workflows/backend-pr.yaml
@@ -61,7 +61,10 @@ jobs:
           name: backend-code-coverage-report
           path: ./backend/coverage
 
-      # - name: Upload code coverage results to code coverage service
+      - name: Upload test coverage results to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          base-path: ./backend/coverage
 
   e2e-tests:
     uses: ./.github/workflows/e2e-tests.yaml

--- a/.github/workflows/frontend-deploy.yaml
+++ b/.github/workflows/frontend-deploy.yaml
@@ -62,7 +62,10 @@ jobs:
           name: frontend-code-coverage-report
           path: ./frontend/coverage
 
-      # - name: Upload code coverage results to code coverage service
+      - name: Upload test coverage results to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          base-path: ./frontend/coverage
 
   e2e-tests:
     uses: ./.github/workflows/e2e-tests.yaml

--- a/.github/workflows/frontend-pr.yaml
+++ b/.github/workflows/frontend-pr.yaml
@@ -61,7 +61,10 @@ jobs:
           name: frontend-code-coverage-report
           path: ./frontend/coverage
 
-      # - name: Upload code coverage results to code coverage service
+      - name: Upload test coverage results to Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          base-path: ./frontend/coverage
 
   e2e-tests:
     uses: ./.github/workflows/e2e-tests.yaml


### PR DESCRIPTION
Added step to upload test coverage results to Coveralls in GHA CI actions.
COVERALLS_REPO_TOKEN added to GitHub secrets.