### PR TITLE
Move .env loading to app.js

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -1,5 +1,12 @@
 const express = require("express");
 
+// Load test environment variables when running tests
+if (process.env.NODE_ENV === "test") {
+  require("dotenv").config({ path: ".env.test" });
+} else {
+  require("dotenv").config({ path: ".env" });
+}
+
 const app = express();
 
 app.get("/healthz", (req, res) => {

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,12 +1,5 @@
 const app = require("./app");
 
-// Load test environment variables when running tests
-if (process.env.NODE_ENV === "test") {
-  require("dotenv").config({ path: ".env.test" });
-} else {
-  require("dotenv").config({ path: ".env" });
-}
-
 const port = process.env.PORT || 5000;
 
 app.listen(port, () => {


### PR DESCRIPTION
`server.js` was not being loaded during tests so the env files were not being read correctly. `app.js` is loaded normally and when running tests so it's a better place for these.