### PR TITLE
Add local test run script

### DIFF
--- a/backend/.env.test
+++ b/backend/.env.test
@@ -1,1 +1,1 @@
-DATABASE_URL="mysql://testuser:testpass@127.0.0.1:3306/test"
+DATABASE_URL="mysql://root:pass@127.0.0.1:3306/test"

--- a/backend/localtestrun.sh
+++ b/backend/localtestrun.sh
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -e
+
+export DATABASE_URL="mysql://root:pass@127.0.0.1:3306/test"
+
+npx dbmate drop # drop the test database
+npx dbmate --no-dump-schema up # run DB migrations
+mysql -h 127.0.0.1 -u root -ppass test < ./db/testdata/file.sql # insert test data
+npm run test # run tests

--- a/backend/package.json
+++ b/backend/package.json
@@ -10,7 +10,8 @@
     "lint:fix": "eslint --fix .",
     "test": "jest --coverage",
     "test:run": "jest --coverage --forceExit",
-    "test:debug": "jest --coverage --detectOpenHandles"
+    "test:debug": "jest --coverage --detectOpenHandles",
+    "test:clean": "./localtestrun.sh"
   },
   "author": "",
   "license": "ISC",


### PR DESCRIPTION
Makes it easier to run tests when developing.
Drops the test database, runs migrations, inserts test data, runs tests.

`npm run test:clean`