### PR TITLE
Unify mysql user and password for all tests

### DIFF
--- a/.github/workflows/backend-deploy.yaml
+++ b/.github/workflows/backend-deploy.yaml
@@ -40,17 +40,16 @@ jobs:
         with:
           distribution: "mysql"
           mysql-version: "8.1"
-          user: testuser
-          password: testpass
+          root-password: pass
 
       - name: Init DB
         working-directory: ./backend
         env:
-          TEST_DATABASE_URL: "mysql://testuser:testpass@127.0.0.1:3306/test"
+          TEST_DATABASE_URL: "mysql://root:pass@127.0.0.1:3306/test"
         run: |
           npx -y dbmate -e TEST_DATABASE_URL --no-dump-schema up
           # insert test data
-          mysql -h 127.0.0.1 -u testuser -ptestpass test < ./db/testdata/file.sql
+          mysql -h 127.0.0.1 -u root -ppass test < ./db/testdata/file.sql
 
       - name: Run tests
         working-directory: ./backend

--- a/.github/workflows/backend-pr.yaml
+++ b/.github/workflows/backend-pr.yaml
@@ -39,17 +39,16 @@ jobs:
         with:
           distribution: "mysql"
           mysql-version: "8.1"
-          user: testuser
-          password: testpass
+          root-password: pass
 
       - name: Init DB
         working-directory: ./backend
         env:
-          TEST_DATABASE_URL: "mysql://testuser:testpass@127.0.0.1:3306/test"
+          TEST_DATABASE_URL: "mysql://root:pass@127.0.0.1:3306/test"
         run: |
           npx -y dbmate -e TEST_DATABASE_URL --no-dump-schema up
           # insert test data
-          mysql -h 127.0.0.1 -u testuser -ptestpass test < ./db/testdata/file.sql
+          mysql -h 127.0.0.1 -u root -ppass test < ./db/testdata/file.sql
 
       - name: Run tests
         working-directory: ./backend

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -15,17 +15,16 @@ jobs:
         with:
           distribution: "mysql"
           mysql-version: "8.1"
-          user: testuser
-          password: testpass
+          root-password: pass
 
       - name: Init DB
         working-directory: ./backend
         env:
-          TEST_DATABASE_URL: "mysql://testuser:testpass@127.0.0.1:3306/test"
+          TEST_DATABASE_URL: "mysql://root:pass@127.0.0.1:3306/test"
         run: |
           npx -y dbmate -e TEST_DATABASE_URL --no-dump-schema up
           # possibly also want insert test data
-          # mysql -h 127.0.0.1 -u testuser -ptestpass test < ./db/testdata/file.sql
+          # mysql -h 127.0.0.1 -u root -ppass test < ./db/testdata/file.sql
 
       - name: Install NodeJS
         uses: actions/setup-node@v3

--- a/.github/workflows/frontend-deploy.yaml
+++ b/.github/workflows/frontend-deploy.yaml
@@ -40,17 +40,16 @@ jobs:
         with:
           distribution: "mysql"
           mysql-version: "8.1"
-          user: testuser
-          password: testpass
+          root-password: pass
 
       - name: Init DB
         working-directory: ./backend
         env:
-          TEST_DATABASE_URL: "mysql://testuser:testpass@127.0.0.1:3306/test"
+          TEST_DATABASE_URL: "mysql://root:pass@127.0.0.1:3306/test"
         run: |
           npx -y dbmate -e TEST_DATABASE_URL --no-dump-schema up
           # insert test data
-          mysql -h 127.0.0.1 -u testuser -ptestpass test < ./db/testdata/file.sql
+          mysql -h 127.0.0.1 -u root -ppass test < ./db/testdata/file.sql
 
       - name: Run tests
         working-directory: ./frontend

--- a/.github/workflows/frontend-pr.yaml
+++ b/.github/workflows/frontend-pr.yaml
@@ -39,17 +39,16 @@ jobs:
         with:
           distribution: "mysql"
           mysql-version: "8.1"
-          user: testuser
-          password: testpass
+          root-password: pass
 
       - name: Init DB
         working-directory: ./backend
         env:
-          TEST_DATABASE_URL: "mysql://testuser:testpass@127.0.0.1:3306/test"
+          TEST_DATABASE_URL: "mysql://root:pass@127.0.0.1:3306/test"
         run: |
           npx -y dbmate -e TEST_DATABASE_URL --no-dump-schema up
           # insert test data
-          mysql -h 127.0.0.1 -u testuser -ptestpass test < ./db/testdata/file.sql
+          mysql -h 127.0.0.1 -u root -ppass test < ./db/testdata/file.sql
 
       - name: Run tests
         working-directory: ./frontend


### PR DESCRIPTION
Tests were not running correctly on Ci because of different DB creds. It might be best if we just make them all use the same creds.