### PR TITLE
Include only user id and role id in jsonwebtoken payload #30

### DIFF
--- a/backend/controllers/users.js
+++ b/backend/controllers/users.js
@@ -117,8 +117,13 @@ const login = async (req, res) => {
     premium: user.premium
   };
 
+  const tokenPayload = {
+    id: user.id,
+    role_id: user.role_id
+  };
+
   try {
-    jwt.sign(authenticatedUser, process.env.JWT_KEY, (error, token) => {
+    jwt.sign(tokenPayload, process.env.JWT_KEY, (error, token) => {
       if (error) throw error;
       authenticatedUser.token = token;
       res.send(authenticatedUser);

--- a/backend/controllers/users.js
+++ b/backend/controllers/users.js
@@ -55,6 +55,8 @@ const signup = async (req, res) => {
     jwt.sign(tokenPayload, process.env.JWT_KEY, (err, token) => {
       if (err) throw err;
       createdUser.token = token;
+      // role_id is returned only as part of the JSON Web Token.
+      delete createdUser.role_id;
       res.status(201).send(createdUser);
     });
   } catch (error) {

--- a/backend/controllers/users.js
+++ b/backend/controllers/users.js
@@ -45,11 +45,17 @@ const signup = async (req, res) => {
 
   try {
     const createdUser = await userModels.create(newUser);
-    if (createdUser.length === 0) throw new Error("Failed to create new user");
-    jwt.sign(createdUser[0], process.env.JWT_KEY, (err, token) => {
+    if (!createdUser) throw new Error("Failed to create new user");
+
+    const tokenPayload = {
+      id: createdUser.id,
+      role_id: createdUser.role_id
+    };
+
+    jwt.sign(tokenPayload, process.env.JWT_KEY, (err, token) => {
       if (err) throw err;
-      createdUser[0].token = token;
-      res.status(201).send(createdUser[0]);
+      createdUser.token = token;
+      res.status(201).send(createdUser);
     });
   } catch (error) {
     return res.status(500).send(error.message);

--- a/backend/models/users.js
+++ b/backend/models/users.js
@@ -8,7 +8,7 @@ const users = {
    */
   findByEmail: async (email) => {
     const queryString = `
-      SELECT users.id, roles.name AS role, users.first_name, users.last_name, users.email, users.postal_code, users.city, users.country, users.phone, users.premium, users.password
+      SELECT users.id, users.role_id, roles.name AS role, users.first_name, users.last_name, users.email, users.postal_code, users.city, users.country, users.phone, users.premium, users.password
       FROM users
       LEFT JOIN roles ON users.role_id = roles.id
       WHERE email = ?;`;

--- a/backend/models/users.js
+++ b/backend/models/users.js
@@ -32,7 +32,7 @@ const users = {
 
     const fetchString = "SELECT id, email FROM users WHERE id = ?;";
     const [createdUser] = await promisePool.query(fetchString, [user.id]);
-    return createdUser;
+    return createdUser[0];
   }
 };
 

--- a/backend/models/users.js
+++ b/backend/models/users.js
@@ -30,7 +30,11 @@ const users = {
       [user.id, user.email, user.password]
     ]);
 
-    const fetchString = "SELECT id, email FROM users WHERE id = ?;";
+    const fetchString = `
+      SELECT id, email, role_id 
+      FROM users
+      WHERE id = ?;
+      `;
     const [createdUser] = await promisePool.query(fetchString, [user.id]);
     return createdUser[0];
   }


### PR DESCRIPTION
Update the login API endpoint to only include user id and role id in the jsonwebtoken payload. Updated the users database model for finding a user based on their email to retrieve both user's role id and role name.

Closes #30 