### PR TITLE
Fix RegEx for checking passwords

### DIFF
--- a/backend/controllers/users.js
+++ b/backend/controllers/users.js
@@ -12,7 +12,7 @@ const signup = async (req, res) => {
     email: Joi.string().email().required(),
     password: Joi.string()
       .pattern(
-        new RegExp("^(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[0-9])[a-zA-Z].{8,}$")
+        new RegExp("^(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[0-9]).{8,}$")
       )
       .required()
   });
@@ -77,7 +77,7 @@ const login = async (req, res) => {
       .pattern(
         // Password must be at least 8 characters long,
         // contain at least one upper case letter, one lower case letter and one number.
-        new RegExp("^(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[0-9])[a-zA-Z].{8,}$")
+        new RegExp("^(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[0-9]).{8,}$")
       )
       .required()
   });

--- a/backend/controllers/users.js
+++ b/backend/controllers/users.js
@@ -11,9 +11,7 @@ const signup = async (req, res) => {
   const schema = Joi.object({
     email: Joi.string().email().required(),
     password: Joi.string()
-      .pattern(
-        new RegExp("^(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[0-9]).{8,}$")
-      )
+      .pattern(new RegExp("^(?=.*?[a-z])(?=.*?[A-Z])(?=.*?[0-9]).{8,}$"))
       .required()
   });
 


### PR DESCRIPTION
Update RegEx to match passwords with a minimum length of eight characters.

Closes #48 