### PR TITLE
Change GHA PR workflows to checkout HEAD of the PR

### DIFF
--- a/.github/workflows/backend-pr.yaml
+++ b/.github/workflows/backend-pr.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Install NodeJS
         uses: actions/setup-node@v3

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -9,6 +9,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Install DB
         uses: shogo82148/actions-setup-mysql@v1.23.0
@@ -69,7 +71,7 @@ jobs:
         with:
           name: e2e-test-videos
           path: ./frontend/cypress/videos
-      
+
       - name: Upload test coverage results to Coveralls
         uses: coverallsapp/github-action@v2
         with:

--- a/.github/workflows/frontend-pr.yaml
+++ b/.github/workflows/frontend-pr.yaml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: Install NodeJS
         uses: actions/setup-node@v3


### PR DESCRIPTION
By default GHA action `actions/checkout` uses GITHUB_REF as the ref, which is the merge commit hash for PRs.
The reason for this change is that we had a PR that when merged would fail linting check while being confusing, as the linting passed on the branch which was behind the target branch (main).

example of issue: https://github.com/JuhoBjn/online-store/actions/runs/6720164713/job/18278040362#step:5:20 (appears if commit ea5d228d66 is merged into ba314f966b)