### PR TITLE
Add explicit nullability to fix issue with older MySQL

### DIFF
--- a/backend/db/migrations/20231028173329_add-chat-table.sql
+++ b/backend/db/migrations/20231028173329_add-chat-table.sql
@@ -4,7 +4,7 @@ CREATE TABLE `chats` (
   `type` ENUM('direct', 'group') NOT NULL,
   `name` VARCHAR(32) NOT NULL DEFAULT 'New chat',
   `created_at` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  `last_message_at` TIMESTAMP DEFAULT NULL,
+  `last_message_at` TIMESTAMP NULL DEFAULT NULL,
   PRIMARY KEY (`chat_id`)
 );
 


### PR DESCRIPTION
Older MySQL versions need to have the NULL defined explicitly, while newer versions handle it being missing. TAMK is running 5.7 while we tested on MySQL 8.