### PR TITLE
Add payment page

### DIFF
--- a/frontend/cypress/e2e/frontpage.cy.js
+++ b/frontend/cypress/e2e/frontpage.cy.js
@@ -25,22 +25,12 @@ describe("The front page", () => {
     cy.get("#join-button").should("be.visible");
   });
 
-  it("should allow a user to navigate to signup/login through the join button", () => {
+  it("should allow a user to navigate to payment page through the join button", () => {
     cy.visit(`${Cypress.config("baseUrl")}/frontpage`);
 
     cy.get("#join-button").should("be.visible");
     cy.get("#join-button").click();
 
-    cy.url().should("be.equal", `${Cypress.config("baseUrl")}/auth#signup`);
-  });
-
-  it("should allow a user to navigate to signup/login through the sign up / log in button", () => {
-    cy.visit(`${Cypress.config("baseUrl")}/frontpage`);
-
-    cy.get(
-      ".logged-out-navigation-button-container > .button-container > .button"
-    ).click();
-
-    cy.url().should("be.equal", `${Cypress.config("baseUrl")}/auth`);
+    cy.url().should("be.equal", `${Cypress.config("baseUrl")}/payment`);
   });
 });

--- a/frontend/cypress/e2e/payment.cy.js
+++ b/frontend/cypress/e2e/payment.cy.js
@@ -1,0 +1,35 @@
+describe("The payment page", () => {
+  it("should allow a user to navigate to the payment page", () => {
+    cy.visit(`${Cypress.config("baseUrl")}/payment`);
+    cy.url().should("be.equal", `${Cypress.config("baseUrl")}/payment`);
+  });
+
+  it("should display information about payment", () => {
+    cy.visit(`${Cypress.config("baseUrl")}/payment`);
+
+    cy.get('[data-testid="payment-page-title"]').should("be.visible");
+    cy.get('[data-testid="payment-page-introduction"]').should("be.visible");
+    cy.get('[data-testid="payment-page-submit"]').should("exist");
+  });
+
+  it("should not allow a user to proceed without filling in the form", () => {
+    cy.visit(`${Cypress.config("baseUrl")}/payment`);
+
+    cy.get('[data-testid="payment-page-submit"]').click();
+
+    cy.url().should("be.equal", `${Cypress.config("baseUrl")}/payment`);
+  });
+
+  it("should allow a user to navigate to signup/login through the submit button after filling in the form", () => {
+    cy.visit(`${Cypress.config("baseUrl")}/payment`);
+
+    cy.get('[name="number"]').type("5555555555554444");
+    cy.get('[name="name"]').type("Test User");
+    cy.get('[name="expiry"]').type("0222");
+    cy.get('[name="cvc"]').type("123");
+
+    cy.get('[data-testid="payment-page-submit"]').click();
+
+    cy.url().should("be.equal", `${Cypress.config("baseUrl")}/auth#signup`);
+  });
+});

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -19,6 +19,7 @@
         "@mui/styled-engine": "^5.14.18",
         "jest": "^29.7.0",
         "react": "^18.2.0",
+        "react-credit-cards-2": "^1.0.1",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.17.0",
         "socket.io-client": "^4.7.2"
@@ -6054,6 +6055,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/credit-card-type": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/credit-card-type/-/credit-card-type-9.1.0.tgz",
+      "integrity": "sha512-CpNFuLxiPFxuZqhSKml3M+t0K/484pMAnfYWH14JoD7OZMnmC0Lmo+P7JX9SobqFpRoo7ifA18kOHdxJywYPEA=="
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -6581,7 +6587,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
       "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.1",
         "gopd": "^1.0.1",
@@ -6607,7 +6612,6 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.2.1.tgz",
       "integrity": "sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==",
-      "dev": true,
       "dependencies": {
         "define-data-property": "^1.0.1",
         "has-property-descriptors": "^1.0.0",
@@ -7915,7 +7919,6 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
       "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
-      "dev": true,
       "dependencies": {
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
@@ -8048,7 +8051,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
       "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
-      "dev": true,
       "dependencies": {
         "define-properties": "^1.1.3"
       },
@@ -8083,7 +8085,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -8123,7 +8124,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
       "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
-      "dev": true,
       "dependencies": {
         "get-intrinsic": "^1.2.2"
       },
@@ -8135,7 +8135,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
       "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -8147,7 +8146,6 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -11563,6 +11561,14 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/luhn": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/luhn/-/luhn-2.4.1.tgz",
+      "integrity": "sha512-p1eEWSb2RJAfv+BzrPEUqbUXV1H3ylHEAOk9yDM1L12ojD6OQQGrE29DqKLa0XYluJTIwXIOFmyzVOme3QSyww==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/lz-string": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
@@ -12138,7 +12144,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.1.tgz",
       "integrity": "sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==",
-      "dev": true,
       "engines": {
         "node": ">= 0.4"
       }
@@ -12442,6 +12447,15 @@
       "dev": true,
       "engines": {
         "node": "*"
+      }
+    },
+    "node_modules/payment": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/payment/-/payment-2.4.6.tgz",
+      "integrity": "sha512-QSCAa1yQSkqbe4Ghac3sSA5SQ+Cxc3e4xwCxxun5NT6hUSWsNXXlN8KCCY0kAFFXBP9C7DrfyXP4REB7nPJa8g==",
+      "dependencies": {
+        "globalthis": "^1.0.2",
+        "qj": "~2.0.0"
       }
     },
     "node_modules/pend": {
@@ -12809,6 +12823,11 @@
         }
       ]
     },
+    "node_modules/qj": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/qj/-/qj-2.0.0.tgz",
+      "integrity": "sha512-8466vlnAF/piI42tzMBUfhaAWn2yBNPOLSSbA2YBlEh+S8CxBXbAO1AwuDReGKYX6LlsK19wBL9cpXZGlgsXxA=="
+    },
     "node_modules/qs": {
       "version": "6.10.4",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.10.4.tgz",
@@ -12869,6 +12888,19 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-credit-cards-2": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/react-credit-cards-2/-/react-credit-cards-2-1.0.1.tgz",
+      "integrity": "sha512-H/zkja3X9a8fDMCiFLi0hszJvGCi2O4cCbTqGJUYYjC7sumb1XA+hAnJ3A4Ej5i+T8JF0zoGIqVJXfwMxoMwuw==",
+      "dependencies": {
+        "credit-card-type": "^9.1.0",
+        "luhn": "^2.4.1",
+        "payment": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/react-dom": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -28,6 +28,7 @@
     "@mui/styled-engine": "^5.14.18",
     "jest": "^29.7.0",
     "react": "^18.2.0",
+    "react-credit-cards-2": "^1.0.1",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.17.0",
     "socket.io-client": "^4.7.2"

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -43,6 +43,7 @@ import PostedArticles from "./pages/caretaker/posted-articles/PostedArticles";
 import { MyArticlesLoader } from "./pages/caretaker/posted-articles/PostedArticlesLoader";
 import EditArticle from "./pages/caretaker/edit-article/EditArticle";
 import { EditArticleLoader } from "./pages/caretaker/edit-article/EditArticleLoader";
+import Payment from "./pages/payment/Payment";
 
 import "./App.css";
 
@@ -214,6 +215,14 @@ const router = createBrowserRouter([
       <>
         <LoggedOutNavBar />
         <ContactUs />
+      </>
+    )
+  },
+  {
+    path: "/payment",
+    element: (
+      <>
+        <Payment />
       </>
     )
   },

--- a/frontend/src/pages/frontpage/Frontpage.jsx
+++ b/frontend/src/pages/frontpage/Frontpage.jsx
@@ -9,8 +9,8 @@ import "./Frontpage.css";
 const Frontpage = () => {
   const navigate = useNavigate();
 
-  const navigateToSignupHandler = () => {
-    navigate("/auth#signup");
+  const navigateToPaymentHandler = () => {
+    navigate("/payment");
   };
 
   // Redirect user to the news page if they're logged in.
@@ -54,7 +54,7 @@ const Frontpage = () => {
         id="join-button"
         data-testid="join-button"
         type="confirm"
-        onClick={navigateToSignupHandler}
+        onClick={navigateToPaymentHandler}
       >
         Join
       </Button>

--- a/frontend/src/pages/payment/Payment.css
+++ b/frontend/src/pages/payment/Payment.css
@@ -1,0 +1,63 @@
+.payment-page {
+  /* height = 100 viewport height - navbar */
+  height: calc(100vh - 5em);
+  width: 100vw;
+  padding-top: 5em;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  background-color: var(--main-background-color);
+  overflow-y: scroll;
+  overflow-x: hidden;
+}
+
+.payment-page-container {
+  height: 100%;
+  width: calc(100% - 2 * 2em);
+  max-width: 60em;
+  padding: 0 2em;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+.payment-page-header {
+  width: fit-content;
+  height: fit-content;
+  align-self: flex-start;
+  padding: 0.5em;
+  margin-top: 3em;
+  background-color: var(--light-green);
+}
+
+#payment-page-title {
+  margin: 0;
+}
+
+.payment-page-content {
+  padding-top: 1em;
+  width: 90%;
+  max-width: 60em;
+}
+
+.payment-page-form {
+  margin-top: 1rem;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-start;
+  align-items: center;
+}
+
+input {
+  width: 100%;
+  height: 2.5em;
+  margin-bottom: 1em;
+  padding: 0 0.5em;
+  border: 1px solid var(--light-green);
+  border-radius: 0.5em;
+  font-size: 1em;
+  font-family: var(--main-font);
+}

--- a/frontend/src/pages/payment/Payment.jsx
+++ b/frontend/src/pages/payment/Payment.jsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import "./Payment.css";
+import Cards from "react-credit-cards-2";
+import "react-credit-cards-2/dist/es/styles-compiled.css";
+import Button from "../../components/button/Button";
+import { useNavigate } from "react-router";
+
+const Payment = () => {
+  const [state, setState] = useState({
+    number: "",
+    expiry: "",
+    cvc: "",
+    name: "",
+    focus: ""
+  });
+  const navigate = useNavigate();
+
+  const handleInputChange = (evt) => {
+    const { name, value } = evt.target;
+
+    setState((prev) => ({ ...prev, [name]: value }));
+  };
+
+  const handleInputFocus = (evt) => {
+    setState((prev) => ({ ...prev, focus: evt.target.name }));
+  };
+
+  const submitHandler = (e) => {
+    e.preventDefault();
+    // Do something with the payment information here
+    navigate("/auth#signup");
+  };
+
+  return (
+    <div className="payment-page">
+      <div className="payment-page-container">
+        <header
+          data-testid="payment-page-header"
+          className="payment-page-header"
+        >
+          <h1 data-testid="payment-page-title" id="payment-page-title">
+            GoldenAge payment
+          </h1>
+        </header>
+        <section className="payment-page-content">
+          <p data-testid="payment-page-introduction">
+            At GoldenAge we believe that everyone should have a taste of our
+            wide range of activities and events. That is why we offer a free
+            30-day trial period for all new users. After the trial period, you
+            can continue to enjoy our services for only 14.99€/month. You can
+            cancel your subscription at any time. You will not be charged until
+            the end of your trial period. (This is a demo site, no payment will
+            be made or payment information sent to any server)
+          </p>
+        </section>
+        <Cards
+          number={state.number}
+          expiry={state.expiry}
+          cvc={state.cvc}
+          name={state.name}
+          focused={state.focus}
+        />
+        <form className="payment-page-form" onSubmit={submitHandler}>
+          <input
+            type="number"
+            name="number"
+            placeholder="Card Number"
+            value={state.number}
+            onChange={handleInputChange}
+            onFocus={handleInputFocus}
+            required
+          />
+          <input
+            type="text"
+            name="name"
+            placeholder="Name"
+            value={state.name}
+            onChange={handleInputChange}
+            onFocus={handleInputFocus}
+            required
+          />
+          <input
+            type="text"
+            name="expiry"
+            placeholder="MM/YY Expiry"
+            value={state.expiry}
+            onChange={handleInputChange}
+            onFocus={handleInputFocus}
+            required
+          />
+          <input
+            type="text"
+            name="cvc"
+            placeholder="CVC"
+            value={state.cvc}
+            onChange={handleInputChange}
+            onFocus={handleInputFocus}
+            required
+            onBlur={() => setState((prev) => ({ ...prev, focus: "" }))} // Remove focus when user clicks away
+          />
+
+          <Button testId="payment-page-submit" type="action">
+            Submit
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default Payment;


### PR DESCRIPTION
Adds a (fake) payment page after clicking the Join button on the front page.

The payment page is not being enforced in any way so one can just skip payment page by going to `/auth` , this way tests keep working (I fixed the ones that specifically tested the Join button -> auth, so now it goes Join -> payment and payment -> auth).

(The form has no input validation apart from that they have to be filled.)

https://github.com/JuhoBjn/online-store/assets/38670296/8f6c54ef-cb51-49a2-9557-46f26a5c58ab

