### PR TITLE
Adjust frontpage background element height #160

### DIFF
--- a/frontend/src/pages/frontpage/Frontpage.css
+++ b/frontend/src/pages/frontpage/Frontpage.css
@@ -1,6 +1,6 @@
 .frontpage {
   /* height = 100% - navbar */
-  height: calc(100% - 7em);
+  height: calc(100dvh - 7em);
   width: 100vw;
   margin-top: 7em;
   display: flex;


### PR DESCRIPTION
Set height of the frontpage background to 100dvh to cover the page. Previously, the height would be 0px leaving the background white.